### PR TITLE
Compatibility with plugin2

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -5,6 +5,7 @@ copyright_holder = Yanick Champoux
 copyright_year   = 2013
 
 [Prereqs]
+Dancer2 = 0.162000
 Moo = 1.000007
 
 [@Filter]

--- a/lib/Dancer2/Plugin/Cache/CHI.pm
+++ b/lib/Dancer2/Plugin/Cache/CHI.pm
@@ -6,8 +6,6 @@ use warnings;
 use Carp;
 use CHI;
 
-use Dancer2 0.162000;
-
 use Dancer2::Plugin;
 
 register_hook 'before_create_cache';
@@ -108,7 +106,7 @@ use the main cache object.
 my %cache;
 my $cache_page; # actually hold the ref to the args
 my $cache_page_key_generator = sub {
-    return $_[0]->request->path;
+    return $_[0]->app->request->path;
 };
 
 on_plugin_import {
@@ -147,10 +145,10 @@ sub _create_cache {
     my $namespace = shift;
     my $args = shift || {};
 
-    $dsl->execute_hook( 'before_create_cache' );
+    $dsl->execute_hook( 'plugin.cache_chi.before_create_cache' );
 
     my %setting = %{
-        $dsl->dancer_app->config->{plugins}{'Cache::CHI'} || {}
+        $dsl->app->config->{plugins}{'Cache::CHI'} || {}
     };
 
     $setting{namespace} = $namespace if defined $namespace;
@@ -191,7 +189,7 @@ register check_page_cache => sub {
 
         if ( $honor_no_cache ) {
 
-            my $req =  $dsl->request;
+            my $req =  $dsl->app->request;
 
             no warnings 'uninitialized';
 


### PR DESCRIPTION
- specify D2 min version in dist.ini since we cannot 'use Dancer2'
- make sure request keyword is called via $dsl->app->request
- use fully-qualified hook name in execute_hook
